### PR TITLE
allow exlude/include only (default definitions)

### DIFF
--- a/neon_mana_utils/messagebus.py
+++ b/neon_mana_utils/messagebus.py
@@ -66,8 +66,8 @@ def tail_messagebus(include: Set[str] = None, exclude: Set[str] = None,
             print(message.serialize())
 
     default_filters = get_event_filters()
-    include = include or default_filters["include"]
-    exclude = exclude or default_filters["exclude"]
+    include = include or default_filters.get("include", [])
+    exclude = exclude or default_filters.get("exclude", [])
 
     print(f"Connecting to "
           f"{client.config.host}:{client.config.port}{client.config.route}")


### PR DESCRIPTION
# Issues
by now, if you define exclude/includes in `filters.yml` it excepts when only defined one of em

https://github.com/NeonGeckoCom/neon-mana-utils/blob/18e4fde2d96ffc6b324b4eab2e96a820ba01b41d/neon_mana_utils/config.py#L107-L110

https://github.com/NeonGeckoCom/neon-mana-utils/blob/18e4fde2d96ffc6b324b4eab2e96a820ba01b41d/neon_mana_utils/messagebus.py#L68-L70
--- 

## Further suggestion (different approach)
As this is designed as "default filters" (at least named as such), the arguments passed should extend those, not replace it

```python
# get_event_filters()
...
include = set()
exclude = set()

if isfile(filters_file):
    with open(filters_file) as f:
        config = yaml.safe_load(f)
        include = set(config.get("include", []))
        exclude = set(config.get("exclude", []))

return {"include": include,
        "exclude": exclude}

# tail_messagebus(include: Set[str] = set(), exclude: Set[str] = set(),....)
...
default_filters = get_event_filters()
include = default_filters["include"].union(include)
exclude = default_filters["exclude"].union(exclude)

