### PR TITLE
Update to use shared version_bump.py script

### DIFF
--- a/.github/workflows/publish_test_build.yml
+++ b/.github/workflows/publish_test_build.yml
@@ -6,9 +6,11 @@ on:
     branches:
       - dev
     paths-ignore:
-      - 'version.py'
+      - 'neon_mana_utils/version.py'
 
 jobs:
   build_and_publish_pypi:
     uses: neongeckocom/.github/.github/workflows/publish_alpha_release.yml@master
     secrets: inherit
+    with:
+      version_file: "neon_mana_utils/version.py"


### PR DESCRIPTION
# Description
Use a shared version_bump.py script instead of per-repo

# Issues
https://github.com/NeonGeckoCom/.github/pull/6

# Other Notes
Will need to update branch to `master` after testing