### PR TITLE
Add intent service interface methods

### DIFF
--- a/neon_mana_utils/cli.py
+++ b/neon_mana_utils/cli.py
@@ -328,6 +328,17 @@ def activate_skill(skill):
     click.echo(f"Requested activation of: {skill}")
 
 
+@neon_mana_cli.command(help="Determine Adapt Intent")
+@click.option("--lang", "-l", default="en-us")
+@click.argument("utterance")
+def get_adapt_response(lang, utterance):
+    from neon_mana_utils.skills import get_adapt_intent
+    client = MessageBusClient(**get_messagebus_config())
+    client.run_in_thread()
+    intent = get_adapt_intent(client, lang, utterance)
+    click.echo(pformat(intent))
+
+
 @neon_mana_cli.command(help="Determine Padatious Intent")
 @click.option("--lang", "-l", default="en-us")
 @click.argument("utterance")

--- a/neon_mana_utils/cli.py
+++ b/neon_mana_utils/cli.py
@@ -326,3 +326,14 @@ def activate_skill(skill):
     client.run_in_thread()
     deactivate_skill(client, skill)
     click.echo(f"Requested activation of: {skill}")
+
+
+@neon_mana_cli.command(help="Determine Padatious Intent")
+@click.option("--lang", "-l", default="en-us")
+@click.argument("utterance")
+def get_padatious_response(lang, utterance):
+    from neon_mana_utils.skills import get_padatious_intent
+    client = MessageBusClient(**get_messagebus_config())
+    client.run_in_thread()
+    intent = get_padatious_intent(client, lang, utterance)
+    click.echo(pformat(intent))

--- a/neon_mana_utils/cli.py
+++ b/neon_mana_utils/cli.py
@@ -281,6 +281,33 @@ def get_skills_list():
     click.echo(pformat(skills))
 
 
+@neon_mana_cli.command(help="Get a list of active skills")
+def get_active_skills():
+    from neon_mana_utils.skills import get_active_skills
+    client = MessageBusClient(**get_messagebus_config())
+    client.run_in_thread()
+    skills = get_active_skills(client)
+    click.echo(pformat(skills))
+
+
+@neon_mana_cli.command(help="Get a list of Adapt intents")
+def get_adapt_manifest():
+    from neon_mana_utils.skills import get_adapt_manifest
+    client = MessageBusClient(**get_messagebus_config())
+    client.run_in_thread()
+    intents = get_adapt_manifest(client)
+    click.echo(pformat(intents))
+
+
+@neon_mana_cli.command(help="Get a list of Padatious intents")
+def get_padatious_manifest():
+    from neon_mana_utils.skills import get_padatious_manifest
+    client = MessageBusClient(**get_messagebus_config())
+    client.run_in_thread()
+    intents = get_padatious_manifest(client)
+    click.echo(pformat(intents))
+
+
 @neon_mana_cli.command(help="Deactivate a skill")
 @click.argument("skill")
 def deactivate_skill(skill):

--- a/neon_mana_utils/cli.py
+++ b/neon_mana_utils/cli.py
@@ -291,20 +291,22 @@ def get_active_skills():
 
 
 @neon_mana_cli.command(help="Get a list of Adapt intents")
-def get_adapt_manifest():
+@click.option("--lang", "-l", default="en-us")
+def get_adapt_manifest(lang):
     from neon_mana_utils.skills import get_adapt_manifest
     client = MessageBusClient(**get_messagebus_config())
     client.run_in_thread()
-    intents = get_adapt_manifest(client)
+    intents = get_adapt_manifest(client, lang)
     click.echo(pformat(intents))
 
 
 @neon_mana_cli.command(help="Get a list of Padatious intents")
-def get_padatious_manifest():
+@click.option("--lang", "-l", default="en-us")
+def get_padatious_manifest(lang):
     from neon_mana_utils.skills import get_padatious_manifest
     client = MessageBusClient(**get_messagebus_config())
     client.run_in_thread()
-    intents = get_padatious_manifest(client)
+    intents = get_padatious_manifest(client, lang)
     click.echo(pformat(intents))
 
 

--- a/neon_mana_utils/skills.py
+++ b/neon_mana_utils/skills.py
@@ -117,5 +117,6 @@ def get_padatious_intent(bus: MessageBusClient, lang: str,
                                          'utterance': utterance},
                                         {"source": ["mana"],
                                          "destination": ["skills"]}),
-                                reply_type="intent.service.padatious.reply")
+                                reply_type="intent.service.padatious.reply",
+                                timeout=10)
     return msg.data.get('intent', dict())

--- a/neon_mana_utils/skills.py
+++ b/neon_mana_utils/skills.py
@@ -79,12 +79,14 @@ def get_active_skills(bus: MessageBusClient) -> list:
     return msg.data.get('skills', list())
 
 
-def get_adapt_manifest(bus: MessageBusClient) -> list:
+def get_adapt_manifest(bus: MessageBusClient, lang: str) -> list:
     """
     Get the manifest of registered Adapt intents
     :param bus: Connected MessageBusClient to query
+    :param lang: BCP-47 lang code to get intents for
     """
     msg = bus.wait_for_response(Message("intent.service.adapt.manifest.get",
+                                        {"lang": lang},
                                         context={"source": ["mana"],
                                                  "destination": ["skills"]}),
                                 reply_type="intent.service.adapt.manifest")
@@ -108,8 +110,8 @@ def get_padatious_intent(bus: MessageBusClient, lang: str,
     """
     Get a Padatious intent for the input utterance
     :param bus: Connected MessageBusClient to query
-    :param lang: language of input utterance
-    :param utterance: input utterance to check
+    :param lang: language of utterance
+    :param utterance: utterance to check
     :returns: dict Padatious intent
     """
     msg = bus.wait_for_response(Message("intent.service.padatious.get",
@@ -118,5 +120,5 @@ def get_padatious_intent(bus: MessageBusClient, lang: str,
                                         {"source": ["mana"],
                                          "destination": ["skills"]}),
                                 reply_type="intent.service.padatious.reply",
-                                timeout=10)
+                                timeout=15)
     return msg.data.get('intent', dict())

--- a/neon_mana_utils/skills.py
+++ b/neon_mana_utils/skills.py
@@ -101,3 +101,21 @@ def get_padatious_manifest(bus: MessageBusClient) -> list:
                                                  "destination": ["skills"]}),
                                 reply_type="intent.service.padatious.manifest")
     return msg.data.get('intents', list())
+
+
+def get_padatious_intent(bus: MessageBusClient, lang: str,
+                         utterance: str) -> dict:
+    """
+    Get a Padatious intent for the input utterance
+    :param bus: Connected MessageBusClient to query
+    :param lang: language of input utterance
+    :param utterance: input utterance to check
+    :returns: dict Padatious intent
+    """
+    msg = bus.wait_for_response(Message("intent.service.padatious.get",
+                                        {'lang': lang,
+                                         'utterance': utterance},
+                                        {"source": ["mana"],
+                                         "destination": ["skills"]}),
+                                reply_type="intent.service.padatious.reply")
+    return msg.data.get('intent', dict())

--- a/neon_mana_utils/skills.py
+++ b/neon_mana_utils/skills.py
@@ -112,12 +112,14 @@ def get_adapt_intent(bus: MessageBusClient, lang: str,
     return msg.data.get('intent', dict())
 
 
-def get_padatious_manifest(bus: MessageBusClient) -> list:
+def get_padatious_manifest(bus: MessageBusClient, lang: str) -> list:
     """
     Get the manifest of registered Padatious intents
     :param bus: Connected MessageBusClient to query
+    :param lang: BCP-47 lang code to get intents for
     """
     msg = bus.wait_for_response(Message("intent.service.padatious.manifest.get",
+                                        {"lang": lang},
                                         context={"source": ["mana"],
                                                  "destination": ["skills"]}),
                                 reply_type="intent.service.padatious.manifest")

--- a/neon_mana_utils/skills.py
+++ b/neon_mana_utils/skills.py
@@ -35,6 +35,7 @@ def get_skills_list(bus: MessageBusClient) -> dict:
     :param bus: Connected MessageBusClient to query
     :returns: dict of loaded skills
     """
+    # TODO: Comp. to `intent.service.skills.get`?
     resp = bus.wait_for_response(
             Message("skillmanager.list",
                     context={"source": ["mana"],
@@ -63,3 +64,40 @@ def activate_skill(bus: MessageBusClient, skill: str):
     bus.emit(Message("intent.service.skills.activate", {'skill_id': skill},
                      context={"source": ["mana"],
                               "destination": ["skills"]}))
+
+
+def get_active_skills(bus: MessageBusClient) -> list:
+    """
+    Get active skills from the intent service
+    :param bus: Connected MessageBusClient to query
+    :returns: list of active skills
+    """
+    msg = bus.wait_for_response(Message("intent.service.active_skills.get",
+                                        context={"source": ["mana"],
+                                                 "destination": ["skills"]}),
+                                reply_type="intent.service.active_skills.reply")
+    return msg.data.get('skills', list())
+
+
+def get_adapt_manifest(bus: MessageBusClient) -> list:
+    """
+    Get the manifest of registered Adapt intents
+    :param bus: Connected MessageBusClient to query
+    """
+    msg = bus.wait_for_response(Message("intent.service.adapt.manifest.get",
+                                        context={"source": ["mana"],
+                                                 "destination": ["skills"]}),
+                                reply_type="intent.service.adapt.manifest")
+    return msg.data.get('intents', list())
+
+
+def get_padatious_manifest(bus: MessageBusClient) -> list:
+    """
+    Get the manifest of registered Padatious intents
+    :param bus: Connected MessageBusClient to query
+    """
+    msg = bus.wait_for_response(Message("intent.service.padatious.manifest.get",
+                                        context={"source": ["mana"],
+                                                 "destination": ["skills"]}),
+                                reply_type="intent.service.padatious.manifest")
+    return msg.data.get('intents', list())

--- a/neon_mana_utils/skills.py
+++ b/neon_mana_utils/skills.py
@@ -93,6 +93,25 @@ def get_adapt_manifest(bus: MessageBusClient, lang: str) -> list:
     return msg.data.get('intents', list())
 
 
+def get_adapt_intent(bus: MessageBusClient, lang: str,
+                     utterance: str) -> dict:
+    """
+    Get an Adapt intent for the input utterance
+    :param bus: Connected MessageBusClient to query
+    :param lang: language of utterance
+    :param utterance: utterance to check
+    :returns: dict Padatious intent
+    """
+    msg = bus.wait_for_response(Message("intent.service.adapt.get",
+                                        {'lang': lang,
+                                         'utterance': utterance},
+                                        {"source": ["mana"],
+                                         "destination": ["skills"]}),
+                                reply_type="intent.service.adapt.reply",
+                                timeout=15)
+    return msg.data.get('intent', dict())
+
+
 def get_padatious_manifest(bus: MessageBusClient) -> list:
     """
     Get the manifest of registered Padatious intents


### PR DESCRIPTION
# Description
Add utils to interact with the skill manager

- `get-active-skills` returns a list of active skills
- `get-adapt-manifest` returns the Adapt manifest of registered intents
- `get-padatious-manifest` returns the Padatious manifest of registered intents
- `get-adapt-response` returns an Adapt intent Message for the given utterance/lang
- `get-padatious-response` returns a Padatious intent Message for the given utterance/lang

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->