### PR TITLE
Revert changes to reduce init latency

### DIFF
--- a/neon_mana_utils/bus_api.py
+++ b/neon_mana_utils/bus_api.py
@@ -29,8 +29,9 @@ import base64
 import os
 from time import time
 from typing import Optional
-from ovos_bus_client import MessageBusClient, Message
+from mycroft_bus_client.client import MessageBusClient
 from neon_utils.file_utils import encode_file_to_base64_string
+from neon_mana_utils.constants import Message
 
 
 def get_stt(messagebus_client: MessageBusClient,

--- a/neon_mana_utils/cli.py
+++ b/neon_mana_utils/cli.py
@@ -30,7 +30,7 @@ from pprint import pformat
 
 import click
 from click_default_group import DefaultGroup
-from ovos_bus_client import MessageBusClient
+from mycroft_bus_client.client import MessageBusClient
 
 from neon_mana_utils.config import get_messagebus_config
 from neon_mana_utils.version import __version__

--- a/neon_mana_utils/constants.py
+++ b/neon_mana_utils/constants.py
@@ -26,8 +26,17 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import json
+
+from mycroft_bus_client.message import Message as _Message
+
 BASE_CONTEXT = {
     "client_name": "mana",
     "client": "mana",
     "source": ["mana"],
 }
+
+
+class Message(_Message):
+    def as_dict(self):
+        return json.loads(self.serialize())

--- a/neon_mana_utils/core_commands.py
+++ b/neon_mana_utils/core_commands.py
@@ -26,8 +26,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from ovos_bus_client import MessageBusClient, Message
-from neon_mana_utils.constants import BASE_CONTEXT
+from mycroft_bus_client.client import MessageBusClient
+from neon_mana_utils.constants import BASE_CONTEXT, Message
 
 
 def start_listening(client: MessageBusClient):

--- a/neon_mana_utils/messagebus.py
+++ b/neon_mana_utils/messagebus.py
@@ -32,12 +32,12 @@ import yaml
 from os.path import expanduser, isfile, abspath
 from typing import Optional
 from threading import Event
-from ovos_bus_client import MessageBusClient, Message
+from mycroft_bus_client.client import MessageBusClient
 from typing import Set
 from pprint import pprint
 
 from neon_mana_utils.config import get_event_filters
-from neon_mana_utils.constants import BASE_CONTEXT
+from neon_mana_utils.constants import BASE_CONTEXT, Message
 
 
 def tail_messagebus(include: Set[str] = None, exclude: Set[str] = None,

--- a/neon_mana_utils/skills.py
+++ b/neon_mana_utils/skills.py
@@ -26,7 +26,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from ovos_bus_client import Message, MessageBusClient
+from mycroft_bus_client.client import MessageBusClient
+from neon_mana_utils.constants import Message
 
 
 def get_skills_list(bus: MessageBusClient) -> dict:

--- a/neon_mana_utils/status.py
+++ b/neon_mana_utils/status.py
@@ -26,7 +26,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from ovos_bus_client import Message, MessageBusClient
+from mycroft_bus_client.client import MessageBusClient
+from neon_mana_utils.constants import Message
 
 
 def check_ready(bus: MessageBusClient,

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 click~=8.0
 click-default-group~=1.2
-ovos-bus-client~=0.0.3
+mycroft-messagebus-client~=0.10
 pyyaml~=5.4
 neon-utils~=1.0
 ovos-utils~=0.0.20


### PR DESCRIPTION
# Description
Refactor back to mycroft-messagebus-client to prevent config init
Implements `Message.as_dict` to suppress logged warnings

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->