### PR TITLE
Include JSON length of omitted `session` context

### DIFF
--- a/neon_mana_utils/messagebus.py
+++ b/neon_mana_utils/messagebus.py
@@ -64,7 +64,9 @@ def tail_messagebus(include: Set[str] = None, exclude: Set[str] = None,
             # Message is specified in excluded types
             return
         if not include_session:
-            message.context.pop("session", None)
+            session = message.context.pop("session", dict())
+            session_len = len(json.dumps(session))
+            message.context["session"] = f"{session_len} chars omitted"
         serialized = message.as_dict()
         if format_output:
             pprint(serialized)


### PR DESCRIPTION
# Description
If omitting session context, include length of omitted json for debugging
`'session': '1498385 chars omitted'`

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->