### PR TITLE
Loosen ovos-utils dependency to allow 0.1

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,4 +3,4 @@ click-default-group~=1.2
 mycroft-messagebus-client~=0.10
 pyyaml>=5.4,<7.0
 neon-utils~=1.0
-ovos-utils~=0.0.20
+ovos-utils~=0.0,>=0.0.20


### PR DESCRIPTION
# Description
<!-- Provide a brief description of this PR -->

# Issues
Closes #39 
Closes #40 

# Other Notes
Will also require an alpha version of `neon-utils` to allow ovos-utils 0-.1.x https://github.com/NeonGeckoCom/neon-utils/pull/507