### PR TITLE
Add helpers for Skill API queries

### DIFF
--- a/neon_mana_utils/cli.py
+++ b/neon_mana_utils/cli.py
@@ -307,6 +307,25 @@ def get_skills_list():
     click.echo(pformat(skills))
 
 
+@neon_mana_cli.command(help="Get the API for a particular skill")
+@click.argument("skill_id")
+def get_skill_api(skill_id):
+    from neon_mana_utils.skills import get_skill_api
+    client = MessageBusClient(**get_messagebus_config())
+    client.run_in_thread()
+    api = get_skill_api(client, skill_id)
+    click.echo(pformat(api))
+
+
+@neon_mana_cli.command(help="Get a list of available skill APIs")
+def get_all_skills_api():
+    from neon_mana_utils.skills import get_all_skills_api
+    client = MessageBusClient(**get_messagebus_config())
+    client.run_in_thread()
+    skills = get_all_skills_api(client)
+    click.echo(pformat(skills))
+
+
 @neon_mana_cli.command(help="Get a list of active skills")
 def get_active_skills():
     from neon_mana_utils.skills import get_active_skills

--- a/neon_mana_utils/skills.py
+++ b/neon_mana_utils/skills.py
@@ -189,7 +189,7 @@ def get_skill_api(bus: MessageBusClient, skill_id: str) -> dict:
     msg = bus.wait_for_response(Message(f"{skill_id}.public_api",
                                         context={"source": ["mana"],
                                                  "destination": ["skills"]}),
-                                reply_type="skillmanager.api.reply")
+                                )
     return msg.data if msg else {}
 
 

--- a/neon_mana_utils/skills.py
+++ b/neon_mana_utils/skills.py
@@ -177,3 +177,34 @@ def get_padatious_intent(bus: MessageBusClient, lang: str,
                                 reply_type="intent.service.padatious.reply",
                                 timeout=15)
     return msg.data.get('intent', dict())
+
+
+def get_skill_api(bus: MessageBusClient, skill_id: str) -> dict:
+    """
+    Get the API for a skill
+    :param bus: Connected MessageBusClient to query
+    :param skill_id: ID of the skill to get API for
+    :returns: dict skill API
+    """
+    msg = bus.wait_for_response(Message(f"{skill_id}.public_api",
+                                        context={"source": ["mana"],
+                                                 "destination": ["skills"]}),
+                                reply_type="skillmanager.api.reply")
+    return msg.data
+
+
+def get_all_skills_api(bus: MessageBusClient) -> dict:
+    """
+    Get a representation of all skill APIs
+    :param bus: Connected MessageBusClient to query
+    :returns: dict of all skill APIs by skill ID
+    """
+    skills = get_skills_list(bus)
+    skills_api = {}
+    for skill in skills.values:
+        if not skill.get('active'):
+            continue
+        skill_api = get_skill_api(bus, skill['id'])
+        skills_api[skill['id']] = skill_api
+    return skills_api
+

--- a/neon_mana_utils/skills.py
+++ b/neon_mana_utils/skills.py
@@ -190,7 +190,7 @@ def get_skill_api(bus: MessageBusClient, skill_id: str) -> dict:
                                         context={"source": ["mana"],
                                                  "destination": ["skills"]}),
                                 reply_type="skillmanager.api.reply")
-    return msg.data
+    return msg.data if msg else {}
 
 
 def get_all_skills_api(bus: MessageBusClient) -> dict:

--- a/neon_mana_utils/skills.py
+++ b/neon_mana_utils/skills.py
@@ -201,7 +201,7 @@ def get_all_skills_api(bus: MessageBusClient) -> dict:
     """
     skills = get_skills_list(bus)
     skills_api = {}
-    for skill in skills.values:
+    for skill in skills.values():
         if not skill.get('active'):
             continue
         skill_api = get_skill_api(bus, skill['id'])


### PR DESCRIPTION
# Description
Adds `get_skill_api` to get the API for a specific skill ID
Add `get_all_skills_api` to get all skill APIs, indexed by Skill ID

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Example output:
```shell
root@neon-core-messagebus-8444b79dcb-qq5wk:/neon_messagebus# mana get-all-skills-api
{'ovos-skill-icanhazdadjokes.openvoiceos': {},
 'skill-about.neongeckocom': {'skill_info_examples': {'help': '\n'
                                                              '        API '
                                                              'Method to build '
                                                              'a list of '
                                                              'examples as '
                                                              'listed in skill '
                                                              'metadata.\n'
                                                              '        ',
                                                      'type': 'skill-about.neongeckocom.skill_info_examples'}},
 'skill-alerts.neongeckocom': {},
...
 'skill-weather.neongeckocom': {'get_current_weather_homescreen': {'help': '',
                                                                   'type': 'skill-weather.neongeckocom.get_current_weather_homescreen'}}}
```